### PR TITLE
Adding StreamableHTTP endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `aws-mcp-gateway` uses a YAML configuration file to define the Lambda functi
 name: LambdaMCPGateway
 version: v1.0.0
 port: 8080
-endpoint: /mcp/sse
+endpoint: /mcp
 
 tools:
   - name: getWeather
@@ -67,12 +67,14 @@ tools:
 
 ### **Fields**
 
-* **name**: Name of the MCP server broadcasted. Defaults to LambdaMCPGateway
-* **version**: Version of the MCP server it will broadcast. Defaults to v1.0.0
-* **endpoint**: The request path to host mcp server at. Defaults to /mcp/sse
-* **port**: The port MCP server is hosted at. Defaults to 8080
-* **tools**: A list of Lambda functions to expose as MCP tools.
+* **server**: Server configuration
+  * **name**: Name of the MCP server broadcasted. Defaults to LambdaMCPGateway
+  * **version**: Version of the MCP server it will broadcast. Defaults to v1.0.0
+  * **mode**: The type of endpoint to run (sse, stream). Defaults to stream
+  * **endpoint**: The request path to host mcp server at. Defaults to /mcp
+  * **port**: The port MCP server is hosted at. Defaults to 8080
 
+* **tools**: A list of Lambda functions to expose as MCP tools.
   * **name**: Unique name for tool as it will appear in MCP.
   * **description**: Short description of the tool’s functionality.
   * **lambdaArn**: The ARN of the Lambda function to invoke.
@@ -81,7 +83,7 @@ tools:
 
 # Usage
 
-Once you've completed either build you can run the aws-mcp-gatewat using executable or docker image. The MCP server will then be available at http://localhost:8080/mcp/sse
+Once you've completed either build you can run the aws-mcp-gatewat using executable or docker image. The MCP server will then be available at http://localhost:8080/mcp
 
 ### Go
 ```sh

--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -21,12 +21,16 @@ var buildTime = "unknown"
 // Configuration values
 var configFile string
 var port int
+var mode string
 var endpoint string
 var versionFlag bool
 
 func argparse() {
 	// Configuration File
 	pflag.StringVarP(&configFile, "files", "f", "tools.yaml", "Path to the tools configuration file")
+
+	// Mode
+	pflag.StringVarP(&mode, "mode", "m", "", "Port for mcp server to use")
 
 	// Port
 	pflag.IntVarP(&port, "port", "p", 0, "Port for mcp server to use")
@@ -56,21 +60,33 @@ func main() {
 
 	// Load config if not specified on cli
 	if port == 0 {
-		port = cfg.Port
+		port = cfg.Server.Port
 	}
 	if endpoint == "" {
-		endpoint = cfg.Endpoint
+		endpoint = cfg.Server.Endpoint
+	}
+	if mode == "" {
+		mode = cfg.Server.Mode
 	}
 
-	server := mcp.NewServer(&mcp.Implementation{Name: cfg.Name, Version: cfg.Version}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: cfg.Server.Name, Version: cfg.Server.Version}, nil)
 
 	tools.Register(server, cfg)
 
 	// SSE endpoint – a simple implementation
-	handler := mcp.NewSSEHandler(func(r *http.Request) *mcp.Server {
-		return server
-	}, nil)
-	http.Handle(endpoint, handler)
+	switch mode {
+	case "sse":
+		http.Handle(endpoint, mcp.NewSSEHandler(func(r *http.Request) *mcp.Server {
+			return server
+		}, nil))
+	case "stream":
+		http.Handle(endpoint, mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+			return server
+		}, nil))
+	default:
+		log.Fatalf("Unknown mode (%s)! Please update server.mode in config. Valid modes: sse, stream", mode)
+	}
+
 	log.Printf("Listening at http://localhost:%d%s", port, endpoint)
 
 	// Serve http server

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -13,12 +13,17 @@ type ToolDef struct {
 	InputSchema map[string]any `yaml:"inputSchema"`
 }
 
+type ServerConfig struct {
+	Name     string `yaml:"name"`
+	Version  string `yaml:"version"`
+	Mode     string `yaml:"mode"`
+	Endpoint string `yaml:"endpoint"`
+	Port     int    `yaml:"port"`
+}
+
 type Config struct {
-	Name     string    `yaml:"name"`
-	Version  string    `yaml:"version"`
-	Endpoint string    `yaml:"endpoint"`
-	Port     int       `yaml:"port"`
-	Tools    []ToolDef `yaml:"tools"`
+	Server ServerConfig `yaml:"server"`
+	Tools  []ToolDef    `yaml:"tools"`
 }
 
 func LoadConfig(path string) (*Config, error) {
@@ -27,12 +32,14 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 
-	// Default Values
 	cfg := &Config{
-		Name:     "LambdaMCPGateway",
-		Version:  "v1.0.0",
-		Endpoint: "/mcp/sse",
-		Port:     8080,
+		Server: ServerConfig{
+			Name:     "LambdaMCPGateway",
+			Version:  "v1.0.0",
+			Mode:     "stream",
+			Endpoint: "/mcp/",
+			Port:     8080,
+		},
 	}
 
 	// Parse YAML into cfg

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -11,10 +11,11 @@ func TestLoadConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	validYAML := `
-name: "MyGateway"
-version: "1.2.3"
-endpoint: "http://localhost"
-port: 8080
+server:
+  name: "MyGateway"
+  version: "1.2.3"
+  endpoint: "http://localhost"
+  port: 8080
 
 tools:
 - name: "ExampleTool"
@@ -38,17 +39,17 @@ tools:
 		}
 
 		// ---- NEW TESTS FOR OPTIONAL FIELDS ----
-		if cfg.Name != "MyGateway" {
-			t.Errorf("expected name 'MyGateway', got %s", cfg.Name)
+		if cfg.Server.Name != "MyGateway" {
+			t.Errorf("expected name 'MyGateway', got %s", cfg.Server.Name)
 		}
-		if cfg.Version != "1.2.3" {
-			t.Errorf("expected version '1.2.3', got %s", cfg.Version)
+		if cfg.Server.Version != "1.2.3" {
+			t.Errorf("expected version '1.2.3', got %s", cfg.Server.Version)
 		}
-		if cfg.Endpoint != "http://localhost" {
-			t.Errorf("expected endpoint 'http://localhost', got %s", cfg.Endpoint)
+		if cfg.Server.Endpoint != "http://localhost" {
+			t.Errorf("expected endpoint 'http://localhost', got %s", cfg.Server.Endpoint)
 		}
-		if cfg.Port != 8080 {
-			t.Errorf("expected port 8080, got %d", cfg.Port)
+		if cfg.Server.Port != 8080 {
+			t.Errorf("expected port 8080, got %d", cfg.Server.Port)
 		}
 
 		// ---- EXISTING TOOL TESTS ----
@@ -99,17 +100,17 @@ tools:
 		}
 
 		// Optional fields should be zero-value
-		if cfg.Name != "LambdaMCPGateway" {
-			t.Errorf("expected default name 'LambdaMCPGateway', got %s", cfg.Name)
+		if cfg.Server.Name != "LambdaMCPGateway" {
+			t.Errorf("expected default name 'LambdaMCPGateway', got %s", cfg.Server.Name)
 		}
-		if cfg.Version != "v1.0.0" {
-			t.Errorf("expected default version 'v1.0.0', got %s", cfg.Version)
+		if cfg.Server.Version != "v1.0.0" {
+			t.Errorf("expected default version 'v1.0.0', got %s", cfg.Server.Version)
 		}
-		if cfg.Endpoint != "/mcp/sse" {
-			t.Errorf("expected default endpoint '/mcp/sse', got %s", cfg.Endpoint)
+		if cfg.Server.Endpoint != "/mcp" {
+			t.Errorf("expected default endpoint '/mcp', got %s", cfg.Server.Endpoint)
 		}
-		if cfg.Port != 8080 {
-			t.Errorf("expected default port 8080, got %d", cfg.Port)
+		if cfg.Server.Port != 8080 {
+			t.Errorf("expected default port 8080, got %d", cfg.Server.Port)
 		}
 
 		if len(cfg.Tools) != 1 {


### PR DESCRIPTION
# Overview
This MR covers added support for streamable http endpoint in addition to SSE. StreamableHTTP will be the new default. It also covers minor changes to configuration now split between server and tools field.

# Changes
- Updated loader.go moving Endpoint, Name, Version, Port to be in Server struct. Also added mode to Server struct
- Updated loader_test.go unit tests
- Updated main.go to support StreamableHTTP as well as add new mode flag

# Issue
Closes #9 